### PR TITLE
Don't export the bearer token from the request

### DIFF
--- a/cfn/entry_test.go
+++ b/cfn/entry_test.go
@@ -152,7 +152,7 @@ func TestInvoke(t *testing.T) {
 			time.Sleep(2 * time.Hour)
 			return handler.ProgressEvent{}
 		}, handler.NewRequest(nil, nil, "foo", "bar"), &requestContext{}, mockPub, createAction,
-		}, handler.NewProgressEvent(), true, 3,
+		}, handler.ProgressEvent{}, true, 3,
 		},
 	}
 	for _, tt := range tests {

--- a/cfn/handler/event.go
+++ b/cfn/handler/event.go
@@ -40,16 +40,18 @@ type ProgressEvent struct {
 
 // NewEvent creates a new event
 // with a default OperationStatus of Unkown
-func NewProgressEvent() ProgressEvent {
+func NewProgressEvent(req Request) ProgressEvent {
 	return ProgressEvent{
 		OperationStatus: UnknownStatus,
+		BearerToken:     req.bearerToken,
 	}
 }
 
 // NewFailedEvent creates a generic failure progress event based on
 // the error passed in.
-func NewFailedEvent(err cfnerr.Error) ProgressEvent {
+func NewFailedEvent(req Request, err cfnerr.Error) ProgressEvent {
 	return ProgressEvent{
+		BearerToken:      req.bearerToken,
 		OperationStatus:  Failed,
 		Message:          err.Message(),
 		HandlerErrorCode: err.Code(),

--- a/cfn/handler/handler_test.go
+++ b/cfn/handler/handler_test.go
@@ -33,12 +33,12 @@ func TestNewRequest(t *testing.T) {
 			t.Fatalf("Properties don't match: %v", curr.Color)
 		}
 
-		if req.BearerToken() != "123" {
-			t.Fatalf("Invalid Bearer Token: %v", req.BearerToken())
+		if req.bearerToken != "123" {
+			t.Fatalf("Invalid Bearer Token: %v", req.bearerToken)
 		}
 
-		if req.LogicalResourceID() != "foo" {
-			t.Fatalf("Invalid Logical Resource ID: %v", req.LogicalResourceID())
+		if req.LogicalResourceID != "foo" {
+			t.Fatalf("Invalid Logical Resource ID: %v", req.LogicalResourceID)
 		}
 
 	})

--- a/cfn/handler/request.go
+++ b/cfn/handler/request.go
@@ -20,19 +20,19 @@ const (
 // Request is passed to actions with customer related data
 // such as resource states
 type Request struct {
+	LogicalResourceID              string
+	bearerToken                    string
 	previousResourcePropertiesBody json.RawMessage
 	resourcePropertiesBody         json.RawMessage
-	logicalResourceID              string
-	bearerToken                    string
 }
 
 // NewRequest returns a new Request based on the provided parameters
 func NewRequest(previousBody json.RawMessage, body json.RawMessage, logicalResourceID string, bearerToken string) Request {
 	return Request{
+		LogicalResourceID:              logicalResourceID,
+		bearerToken:                    bearerToken,
 		previousResourcePropertiesBody: previousBody,
 		resourcePropertiesBody:         body,
-		logicalResourceID:              logicalResourceID,
-		bearerToken:                    bearerToken,
 	}
 }
 
@@ -62,14 +62,4 @@ func (r *Request) Unmarshal(v interface{}) error {
 	}
 
 	return nil
-}
-
-// LogicalResourceID returns the logical ID of the related resource
-func (r *Request) LogicalResourceID() string {
-	return r.logicalResourceID
-}
-
-// BearerToken returns the bearer token related to the request
-func (r *Request) BearerToken() string {
-	return r.bearerToken
 }

--- a/python/rpdk/go/templates/stubHandler.go.tple
+++ b/python/rpdk/go/templates/stubHandler.go.tple
@@ -14,17 +14,16 @@ type Handler struct {
 {% for method in ("Create", "Read", "Update", "Delete", "List") %}
 
 // {{ method }} handles the {{ method }} event from the Cloudformation service.
-func (r *Handler) {{ method }}(ctx context.Context, request handler.Request) handler.ProgressEvent {
+func (r *Handler) {{ method }}(ctx context.Context, req handler.Request) handler.ProgressEvent {
 	//***Add code here: Make your API call, modify the model, etc..
 	m := &Model{}
-	if err := request.Unmarshal(m); err != nil {
+	if err := req.Unmarshal(m); err != nil {
 		cfnErr := cfnerr.New(cfnerr.GeneralServiceException, "Unable to complete request", err)
-		return handler.NewFailedEvent(cfnErr)
+		return handler.NewFailedEvent(req, cfnErr)
 	}
 
-	p := handler.NewProgressEvent()
+	p := handler.NewProgressEvent(req)
 	p.ResourceModel = m
-	p.BearerToken = request.BearerToken()
 	p.OperationStatus = handler.Success
 	p.Message = "Completed"
 


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:*

Simplified the Request type by exporting the LogicalResourceID (instead of using a getter) and hiding the bearer token. As a result, NewProgressEvent requires the event to be passed in.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
