### PR TITLE
Fix session marshal

### DIFF
--- a/cfn/event.go
+++ b/cfn/event.go
@@ -51,8 +51,7 @@ type requestContext struct {
 	CloudWatchEventsRuleName string                 `json:"cloudWatchEventsRuleName,omitempty"`
 	CloudWatchEventsTargetID string                 `json:"cloudWatchEventsTargetId,omitempty"`
 	Invocation               encoding.Int           `json:"invocation,omitempty"`
-
-	Session *session.Session
+	Session                  *session.Session       `json:"omitempty"`
 }
 
 // validateEvent ensures the event struct generated from the Lambda SDK is correct


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
This pull request fixes an issue with marshaling the event.  On a re-invoke, the handler tries to marshal the event with a *session.Session, causing an error. 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
