### PR TITLE
Fix publisher root

### DIFF
--- a/cfn/metrics/publisher.go
+++ b/cfn/metrics/publisher.go
@@ -19,7 +19,7 @@ import (
 
 const (
 	// MetricNameSpaceRoot is the Metric name space root.
-	MetricNameSpaceRoot = "AWS_TMP/CloudFormation"
+	MetricNameSpaceRoot = "AWS/CloudFormation"
 	//MetricNameHanderException  is a metric type.
 	MetricNameHanderException = "HandlerException"
 	//MetricNameHanderDuration is a metric type.

--- a/cfn/metrics/publisher_notag.go
+++ b/cfn/metrics/publisher_notag.go
@@ -18,7 +18,7 @@ import (
 
 const (
 	// MetricNameSpaceRoot is the Metric name space root.
-	MetricNameSpaceRoot = "AWS_TMP/CloudFormation"
+	MetricNameSpaceRoot = "AWS/CloudFormation"
 	//MetricNameHanderException  is a metric type.
 	MetricNameHanderException = "HandlerException"
 	//MetricNameHanderDuration is a metric type.


### PR DESCRIPTION
…tion

*Issue #, if available:*
#101 
*Description of changes:*
The metric namespace should be "AWS/CloudFormation", not "AWS_TMP/CloudFormation" to be consistent with other plugins. 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
