### PR TITLE
Capture output from go fmt

### DIFF
--- a/python/rpdk/go/codegen.py
+++ b/python/rpdk/go/codegen.py
@@ -166,7 +166,9 @@ class GoLanguagePlugin(LanguagePlugin):
         # named files must all be in one directory
         for path in format_paths:
             try:
-                subprocess_run(["go", "fmt", path], cwd=root, check=True)
+                subprocess_run(
+                    ["go", "fmt", path], cwd=root, check=True, capture_output=True
+                )
             except (FileNotFoundError, CalledProcessError) as e:
                 raise DownstreamError("go fmt failed") from e
 


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:* Capture output of `go fmt` so that it doesn't just dump to stdout while running `cfn generate`


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
