### PR TITLE
Require updated cfn plugin. Fix write settings

### DIFF
--- a/python/rpdk/go/__init__.py
+++ b/python/rpdk/go/__init__.py
@@ -1,5 +1,5 @@
 import logging
 
-__version__ = "0.1.3"
+__version__ = "0.1.4"
 
 logging.getLogger(__name__).addHandler(logging.NullHandler())

--- a/python/rpdk/go/codegen.py
+++ b/python/rpdk/go/codegen.py
@@ -24,10 +24,7 @@ EXECUTABLE = "cfn-cli"
 
 LANGUAGE = "go"
 
-DEFAULT_SETTINGS = {
-    "protocolVersion": "1.0",
-    "pluginVersion": __version__,
-}
+DEFAULT_SETTINGS = {"protocolVersion": "1.0", "pluginVersion": __version__}
 
 
 class GoExecutableNotFoundError(SysExitRecommendedError):
@@ -197,7 +194,7 @@ class GoLanguagePlugin(LanguagePlugin):
                     print(*check_version(old), sep="\n")
 
         if need_to_write:
-            project._write_settings(LANGUAGE)
+            project.write_settings()
 
     @staticmethod
     def pre_package(project):

--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,7 @@ setup(
     # package_data -> use MANIFEST.in instead
     include_package_data=True,
     zip_safe=True,
-    install_requires=["cloudformation-cli>=0.1,<0.2", "semver>=2.9.0",],
+    install_requires=["cloudformation-cli>=0.1.2,<0.2", "semver>=2.9.0"],
     python_requires=">=3.6",
     entry_points={"rpdk.v1.languages": ["go = rpdk.go.codegen:GoLanguagePlugin"]},
     license="Apache License 2.0",


### PR DESCRIPTION
*Issue #, if available:* #118

*Description of changes:* With the latest [release](https://pypi.org/project/cloudformation-cli/0.1.2/) of the cloudformation-cli, a private method the go plugin we were relying on was removed and made public. This bumps the cli version we depend on to to force the cli to be this upgraded version and also uses said public method.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
