### PR TITLE
Fix model in reschedule

### DIFF
--- a/cfn/cfn.go
+++ b/cfn/cfn.go
@@ -235,7 +235,12 @@ func reschedule(ctx context.Context, invokeScheduler InvokeScheduler, progEvt ha
 	// Add IDs to recall the function with Cloudwatch events
 	event.RequestContext.CloudWatchEventsRuleName = ids.Handler
 	event.RequestContext.CloudWatchEventsTargetID = ids.Target
-
+	// Update model properties
+	m, err := encoding.Marshal(progEvt.ResourceModel)
+	if err != nil {
+		return false, err
+	}
+	event.RequestData.ResourceProperties = m
 	// Rebuild the context
 	event.RequestContext.CallbackContext = cusCtx
 

--- a/cfn/cfn.go
+++ b/cfn/cfn.go
@@ -309,17 +309,11 @@ func makeEventFunc(h Handler) eventFunc {
 
 			progEvt := processinvoke(handlerFn, event, request, metricsPublisher)
 
-			cusCtx, delay := marshalCallback(&progEvt)
-
 			r, err := newResponse(&progEvt, event.BearerToken)
 			if err != nil {
 				log.Printf("Error creating response: %v", err)
 				return re.report(event, "Response error", err, unmarshalingError)
 			}
-
-			log.Printf("Handler returned  OperationStatus: %v Message: %v CallbackContext: %v Delay: %v, ErrorCode: %v  ",
-				r.OperationStatus, progEvt.Message,
-				cusCtx, delay, progEvt.HandlerErrorCode)
 
 			if !isMutatingAction(event.Action) && r.OperationStatus == handler.InProgress {
 				return re.report(event, "Response error", errors.New("READ and LIST handlers must return synchronous"), invalidRequestError)

--- a/cfn/cfn.go
+++ b/cfn/cfn.go
@@ -199,7 +199,6 @@ func isMutatingAction(action string) bool {
 }
 
 func translateStatus(operationStatus handler.Status) callback.Status {
-
 	switch operationStatus {
 	case handler.Success:
 		return callback.Success
@@ -214,21 +213,17 @@ func translateStatus(operationStatus handler.Status) callback.Status {
 }
 
 func processinvoke(handlerFn handlerFunc, event *event, request handler.Request, metricsPublisher *metrics.Publisher) handler.ProgressEvent {
-
 	progEvt, err := invoke(handlerFn, request, metricsPublisher, event.Action)
-
 	if err != nil {
 		log.Printf("Handler invocation failed: %v", err)
 		return handler.NewFailedEvent(err)
 	}
 	return progEvt
-
 }
 
 func reschedule(ctx context.Context, invokeScheduler InvokeScheduler, progEvt handler.ProgressEvent, event *event) (bool, error) {
 	cusCtx, delay := marshalCallback(&progEvt)
 	ids, err := scheduler.GenerateCloudWatchIDS()
-
 	if err != nil {
 		return false, err
 	}
@@ -243,18 +238,14 @@ func reschedule(ctx context.Context, invokeScheduler InvokeScheduler, progEvt ha
 	event.RequestData.ResourceProperties = m
 	// Rebuild the context
 	event.RequestContext.CallbackContext = cusCtx
-
 	callbackRequest, err := json.Marshal(event)
-
 	if err != nil {
 		return false, err
 	}
 	scheResult, err := invokeScheduler.Reschedule(ctx, delay, string(callbackRequest), ids)
-
 	if err != nil {
 		return false, err
 	}
-
 	return scheResult.ComputeLocal, nil
 }
 
@@ -362,13 +353,10 @@ func makeEventFunc(h Handler) eventFunc {
 // contract testing framework to invoke the resource's CRUDL handlers.
 func makeTestEventFunc(h Handler) testEventFunc {
 	return func(ctx context.Context, event *testEvent) (handler.ProgressEvent, error) {
-
 		handlerFn, err := router(event.Action, h)
-
 		if err != nil {
 			return handler.NewFailedEvent(err), err
 		}
-
 		request := handler.NewRequest(
 			event.Request.LogicalResourceIdentifier,
 			event.CallbackContext,
@@ -376,9 +364,7 @@ func makeTestEventFunc(h Handler) testEventFunc {
 			event.Request.PreviousResourceState,
 			event.Request.DesiredResourceState,
 		)
-
 		progEvt := handlerFn(request)
-
 		return progEvt, nil
 	}
 }

--- a/cfn/test/data/request.create2.json
+++ b/cfn/test/data/request.create2.json
@@ -1,0 +1,27 @@
+{
+    "awsAccountId": "123456789012",
+    "bearerToken": "123456",
+    "region": "us-east-1",
+    "action": "CREATE",
+    "responseEndpoint": "cloudformation.us-west-2.amazonaws.com",
+    "resourceType": "AWS::Test::TestModel",
+    "resourceTypeVersion": "1.0",
+    "requestContext": {},
+    "requestData": {
+        "callerCredentials": {
+            "accessKeyId": "IASAYK835GAIFHAHEI23",
+            "secretAccessKey": "66iOGPN5LnpZorcLr8Kh25u8AbjHVllv5/poh2O0",
+            "sessionToken": "lameHS2vQOknSHWhdFYTxm2eJc1JMn9YBNI4nV4mXue945KPL6DHfW8EsUQT5zwssYEC1NvYP9yD6Y5s5lKR3chflOHPFsIe6eqg"
+        },
+        "platformCredentials": {
+            "accessKeyId": "32IEHAHFIAG538KYASAI",
+            "secretAccessKey": "0O2hop/5vllVHjbA8u52hK8rLcroZpnL5NPGOi66",
+            "sessionToken": "gqe6eIsFPHOlfhc3RKl5s5Y6Dy9PYvN1CEYsswz5TQUsE8WfHD6LPK549euXm4Vn4INBY9nMJ1cJe2mxTYFdhWHSnkOQv2SHemal"
+        },
+        "logicalResourceId": "myBucket",
+        "resourceProperties": {
+            "property1": "abc"
+        }
+    },
+    "stackId": "arn:aws:cloudformation:us-east-1:123456789012:stack/SampleStack/e722ae60-fe62-11e8-9a0e-0ae8cc519968"
+}

--- a/cfn/types_test.go
+++ b/cfn/types_test.go
@@ -109,3 +109,38 @@ type MockScheduler struct {
 func (m MockScheduler) Reschedule(lambdaCtx context.Context, secsFromNow int64, callbackRequest string, invocationIDS *scheduler.ScheduleIDS) (*scheduler.Result, error) {
 	return m.Result, m.Err
 }
+
+// MockModel mocks a resource model
+//
+// This implementation of the handlers is only used for testing.
+type MockModel struct {
+	Property1 *string `json:"property1,omitempty"`
+	Property2 *string `json:"property2,omitempty"`
+}
+
+// MockModelHandler is a implementation of Handler
+//
+// This implementation of the handlers is only used for testing.
+type MockModelHandler struct {
+	fn func(r handler.Request) handler.ProgressEvent
+}
+
+func (m *MockModelHandler) Create(request handler.Request) handler.ProgressEvent {
+	return m.fn(request)
+}
+
+func (m *MockModelHandler) Read(request handler.Request) handler.ProgressEvent {
+	return m.fn(request)
+}
+
+func (m *MockModelHandler) Update(request handler.Request) handler.ProgressEvent {
+	return m.fn(request)
+}
+
+func (m *MockModelHandler) Delete(request handler.Request) handler.ProgressEvent {
+	return m.fn(request)
+}
+
+func (m *MockModelHandler) List(request handler.Request) handler.ProgressEvent {
+	return m.fn(request)
+}


### PR DESCRIPTION
*Issue #, if available:*
#129 
*Description of changes:*
This PR fixes an issue with the primary identifier not being reported during async resource creation. 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
