### PR TITLE
Fix  Handler returning SUCCESS but not returning the primaryIdentifier for the physical resource

### DIFF
--- a/cfn/cfn.go
+++ b/cfn/cfn.go
@@ -320,7 +320,12 @@ func makeEventFunc(h Handler) eventFunc {
 			}
 
 			if isMutatingAction(event.Action) {
-				callbackAdapter.ReportStatus(translateStatus(progEvt.OperationStatus), event.RequestData.ResourceProperties, progEvt.Message, string(r.ErrorCode))
+				m, err := encoding.Marshal(progEvt.ResourceModel)
+				if err != nil {
+					log.Printf("Error reporting status: %v", err)
+					return re.report(event, "Error", err, unmarshalingError)
+				}
+				callbackAdapter.ReportStatus(translateStatus(progEvt.OperationStatus), m, progEvt.Message, string(r.ErrorCode))
 			}
 
 			switch r.OperationStatus {


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
This PR fixes an issue with a Handler returning SUCCESS but not returning the primaryIdentifier for the physical resource.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
