### PR TITLE
Add extra values to handler request

### DIFF
--- a/cfn/cfn.go
+++ b/cfn/cfn.go
@@ -188,8 +188,8 @@ func makeTestEventFunc(h Handler) testEventFunc {
 		request := handler.NewRequest(
 			event.Request.LogicalResourceIdentifier,
 			event.Request.NextToken,
-			"",  //TODO: understand how to fix this to use a proper value
-			nil, //TODO: understand how to fix this to use a proper value
+			event.Request.StackId,  //TODO: understand how to fix this to use a proper value
+			event.Request.StackTags, //TODO: understand how to fix this to use a proper value
 			event.Request.Region,
 			event.Request.AWSAccountID,
 			event.Request.SystemTags,

--- a/cfn/cfn.go
+++ b/cfn/cfn.go
@@ -121,6 +121,12 @@ func makeEventFunc(h Handler) eventFunc {
 		}
 		request := handler.NewRequest(
 			event.RequestData.LogicalResourceID,
+			event.NextToken,
+			event.StackID,
+			event.RequestData.StackTags,
+			event.Region,
+			event.AWSAccountID,
+			event.RequestData.SystemTags,
 			event.CallbackContext,
 			credentials.SessionFromCredentialsProvider(&event.RequestData.CallerCredentials),
 			event.RequestData.PreviousResourceProperties,
@@ -181,6 +187,12 @@ func makeTestEventFunc(h Handler) testEventFunc {
 		}
 		request := handler.NewRequest(
 			event.Request.LogicalResourceIdentifier,
+			event.Request.NextToken,
+			"",  //TODO: understand how to fix this to use a proper value
+			nil, //TODO: understand how to fix this to use a proper value
+			event.Request.Region,
+			event.Request.AWSAccountID,
+			event.Request.SystemTags,
 			event.CallbackContext,
 			credentials.SessionFromCredentialsProvider(&event.Credentials),
 			event.Request.PreviousResourceState,

--- a/cfn/handler/request.go
+++ b/cfn/handler/request.go
@@ -21,6 +21,24 @@ type Request struct {
 	// The logical ID of the resource in the CloudFormation stack
 	LogicalResourceID string
 
+	// The stack ID of the CloudFormation stack
+	StackId string
+
+	// The Region of the requester
+	Region string
+
+	// The Account ID of the requester
+	AccountID string
+
+	// The stack tags associated with the cloudformation stack
+	StackTags map[string]string
+
+	// The SystemTags associated with the request
+	SystemTags map[string]string
+
+	// The NextToken provided in the request
+	NextToken string
+
 	// The callback context is an arbitrary datum which the handler can return in an
 	// IN_PROGRESS event to allow the passing through of additional state or
 	// metadata between subsequent retries; for example to pass through a Resource
@@ -35,9 +53,15 @@ type Request struct {
 }
 
 // NewRequest returns a new Request based on the provided parameters
-func NewRequest(id string, ctx map[string]interface{}, sess *session.Session, previousBody, body []byte) Request {
+func NewRequest(id string, NextToken string, StackId string, StackTags map[string]string, Region string, AccountID string, SystemTags map[string]string, ctx map[string]interface{}, sess *session.Session, previousBody, body []byte) Request {
 	return Request{
 		LogicalResourceID:              id,
+		StackId:                        StackId,
+		Region:                         Region,
+		AccountID:                      AccountID,
+		StackTags:                      StackTags,
+		SystemTags:                     SystemTags,
+		NextToken:                      NextToken,
 		CallbackContext:                ctx,
 		Session:                        sess,
 		previousResourcePropertiesBody: previousBody,


### PR DESCRIPTION
Issue #, if available: #147 

Description of changes:
Added extra variables to the request used by custom resources

- NextToken
- StackID
- StackTags
- Region
- AccountID
- SystemTags

creating a new one for no updates on https://github.com/aws-cloudformation/cloudformation-cli-go-plugin/pull/149

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
