### PR TITLE
Fix log throttle

### DIFF
--- a/cfn/logging/cloudwatchlogs.go
+++ b/cfn/logging/cloudwatchlogs.go
@@ -137,7 +137,6 @@ func CloudWatchLogGroupExists(client cloudwatchlogsiface.CloudWatchLogsAPI, logG
 	})
 
 	if err != nil {
-
 		return false, err
 	}
 

--- a/cfn/logging/cloudwatchlogs.go
+++ b/cfn/logging/cloudwatchlogs.go
@@ -1,7 +1,6 @@
 package logging
 
 import (
-	"context"
 	"io"
 	"log"
 	"os"
@@ -132,15 +131,13 @@ func (p *cloudWatchLogsProvider) Write(b []byte) (int, error) {
 //		// do something
 //	}
 func CloudWatchLogGroupExists(client cloudwatchlogsiface.CloudWatchLogsAPI, logGroupName string) (bool, error) {
-	ctx, cancel := context.WithTimeout(context.Background(), time.Millisecond*500)
-	defer cancel()
-
-	resp, err := client.DescribeLogGroupsWithContext(ctx, &cloudwatchlogs.DescribeLogGroupsInput{
+	resp, err := client.DescribeLogGroups(&cloudwatchlogs.DescribeLogGroupsInput{
 		Limit:              aws.Int64(1),
 		LogGroupNamePrefix: aws.String(logGroupName),
 	})
 
 	if err != nil {
+
 		return false, err
 	}
 
@@ -163,10 +160,7 @@ func CloudWatchLogGroupExists(client cloudwatchlogsiface.CloudWatchLogsAPI, logG
 //		panic("Unable to create log group", err)
 //	}
 func CreateNewCloudWatchLogGroup(client cloudwatchlogsiface.CloudWatchLogsAPI, logGroupName string) error {
-	ctx, cancel := context.WithTimeout(context.Background(), time.Millisecond*500)
-	defer cancel()
-
-	if _, err := client.CreateLogGroupWithContext(ctx, &cloudwatchlogs.CreateLogGroupInput{
+	if _, err := client.CreateLogGroup(&cloudwatchlogs.CreateLogGroupInput{
 		LogGroupName: aws.String(logGroupName),
 	}); err != nil {
 		return err
@@ -177,10 +171,7 @@ func CreateNewCloudWatchLogGroup(client cloudwatchlogsiface.CloudWatchLogsAPI, l
 
 // CreateNewLogStream creates a log stream inside of a LogGroup
 func CreateNewLogStream(client cloudwatchlogsiface.CloudWatchLogsAPI, logGroupName string, logStreamName string) error {
-	ctx, cancel := context.WithTimeout(context.Background(), time.Millisecond*500)
-	defer cancel()
-
-	_, err := client.CreateLogStreamWithContext(ctx, &cloudwatchlogs.CreateLogStreamInput{
+	_, err := client.CreateLogStream(&cloudwatchlogs.CreateLogStreamInput{
 		LogGroupName:  aws.String(logGroupName),
 		LogStreamName: aws.String(logStreamName),
 	})

--- a/cfn/logging/cloudwatchlogs_test.go
+++ b/cfn/logging/cloudwatchlogs_test.go
@@ -1,12 +1,10 @@
 package logging
 
 import (
-	"context"
 	"testing"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/awserr"
-	"github.com/aws/aws-sdk-go/aws/request"
 	"github.com/aws/aws-sdk-go/service/cloudwatchlogs"
 	"github.com/aws/aws-sdk-go/service/cloudwatchlogs/cloudwatchlogsiface"
 )
@@ -14,7 +12,7 @@ import (
 func TestCloudWatchLogProvider(t *testing.T) {
 	t.Run("Init", func(t *testing.T) {
 		client := CallbackCloudWatchLogs{
-			DescribeLogGroupsFn: func(ctx context.Context, input *cloudwatchlogs.DescribeLogGroupsInput) (*cloudwatchlogs.DescribeLogGroupsOutput, error) {
+			DescribeLogGroupsFn: func(input *cloudwatchlogs.DescribeLogGroupsInput) (*cloudwatchlogs.DescribeLogGroupsOutput, error) {
 				return &cloudwatchlogs.DescribeLogGroupsOutput{
 					LogGroups: []*cloudwatchlogs.LogGroup{
 						&cloudwatchlogs.LogGroup{LogGroupName: input.LogGroupNamePrefix},
@@ -22,11 +20,11 @@ func TestCloudWatchLogProvider(t *testing.T) {
 				}, nil
 			},
 
-			CreateLogGroupFn: func(ctx context.Context, input *cloudwatchlogs.CreateLogGroupInput) (*cloudwatchlogs.CreateLogGroupOutput, error) {
+			CreateLogGroupFn: func(input *cloudwatchlogs.CreateLogGroupInput) (*cloudwatchlogs.CreateLogGroupOutput, error) {
 				return nil, nil
 			},
 
-			CreateLogStreamFn: func(ctx context.Context, input *cloudwatchlogs.CreateLogStreamInput) (*cloudwatchlogs.CreateLogStreamOutput, error) {
+			CreateLogStreamFn: func(input *cloudwatchlogs.CreateLogStreamInput) (*cloudwatchlogs.CreateLogStreamOutput, error) {
 				return nil, nil
 			},
 
@@ -45,15 +43,15 @@ func TestCloudWatchLogProvider(t *testing.T) {
 
 	t.Run("Init Error Exists", func(t *testing.T) {
 		client := CallbackCloudWatchLogs{
-			DescribeLogGroupsFn: func(ctx context.Context, input *cloudwatchlogs.DescribeLogGroupsInput) (*cloudwatchlogs.DescribeLogGroupsOutput, error) {
+			DescribeLogGroupsFn: func(input *cloudwatchlogs.DescribeLogGroupsInput) (*cloudwatchlogs.DescribeLogGroupsOutput, error) {
 				return nil, awserr.New("Invalid", "Invalid", nil)
 			},
 
-			CreateLogGroupFn: func(ctx context.Context, input *cloudwatchlogs.CreateLogGroupInput) (*cloudwatchlogs.CreateLogGroupOutput, error) {
+			CreateLogGroupFn: func(input *cloudwatchlogs.CreateLogGroupInput) (*cloudwatchlogs.CreateLogGroupOutput, error) {
 				return nil, nil
 			},
 
-			CreateLogStreamFn: func(ctx context.Context, input *cloudwatchlogs.CreateLogStreamInput) (*cloudwatchlogs.CreateLogStreamOutput, error) {
+			CreateLogStreamFn: func(input *cloudwatchlogs.CreateLogStreamInput) (*cloudwatchlogs.CreateLogStreamOutput, error) {
 				return nil, nil
 			},
 
@@ -72,17 +70,17 @@ func TestCloudWatchLogProvider(t *testing.T) {
 
 	t.Run("Init Error Unable to Create", func(t *testing.T) {
 		client := CallbackCloudWatchLogs{
-			DescribeLogGroupsFn: func(ctx context.Context, input *cloudwatchlogs.DescribeLogGroupsInput) (*cloudwatchlogs.DescribeLogGroupsOutput, error) {
+			DescribeLogGroupsFn: func(input *cloudwatchlogs.DescribeLogGroupsInput) (*cloudwatchlogs.DescribeLogGroupsOutput, error) {
 				return &cloudwatchlogs.DescribeLogGroupsOutput{
 					LogGroups: []*cloudwatchlogs.LogGroup{},
 				}, nil
 			},
 
-			CreateLogGroupFn: func(ctx context.Context, input *cloudwatchlogs.CreateLogGroupInput) (*cloudwatchlogs.CreateLogGroupOutput, error) {
+			CreateLogGroupFn: func(input *cloudwatchlogs.CreateLogGroupInput) (*cloudwatchlogs.CreateLogGroupOutput, error) {
 				return nil, awserr.New("Invalid", "Invalid", nil)
 			},
 
-			CreateLogStreamFn: func(ctx context.Context, input *cloudwatchlogs.CreateLogStreamInput) (*cloudwatchlogs.CreateLogStreamOutput, error) {
+			CreateLogStreamFn: func(input *cloudwatchlogs.CreateLogStreamInput) (*cloudwatchlogs.CreateLogStreamOutput, error) {
 				return nil, nil
 			},
 
@@ -101,7 +99,7 @@ func TestCloudWatchLogProvider(t *testing.T) {
 
 	t.Run("Write", func(t *testing.T) {
 		client := CallbackCloudWatchLogs{
-			DescribeLogGroupsFn: func(ctx context.Context, input *cloudwatchlogs.DescribeLogGroupsInput) (*cloudwatchlogs.DescribeLogGroupsOutput, error) {
+			DescribeLogGroupsFn: func(input *cloudwatchlogs.DescribeLogGroupsInput) (*cloudwatchlogs.DescribeLogGroupsOutput, error) {
 				return &cloudwatchlogs.DescribeLogGroupsOutput{
 					LogGroups: []*cloudwatchlogs.LogGroup{
 						&cloudwatchlogs.LogGroup{LogGroupName: input.LogGroupNamePrefix},
@@ -109,11 +107,11 @@ func TestCloudWatchLogProvider(t *testing.T) {
 				}, nil
 			},
 
-			CreateLogGroupFn: func(ctx context.Context, input *cloudwatchlogs.CreateLogGroupInput) (*cloudwatchlogs.CreateLogGroupOutput, error) {
+			CreateLogGroupFn: func(input *cloudwatchlogs.CreateLogGroupInput) (*cloudwatchlogs.CreateLogGroupOutput, error) {
 				return nil, nil
 			},
 
-			CreateLogStreamFn: func(ctx context.Context, input *cloudwatchlogs.CreateLogStreamInput) (*cloudwatchlogs.CreateLogStreamOutput, error) {
+			CreateLogStreamFn: func(input *cloudwatchlogs.CreateLogStreamInput) (*cloudwatchlogs.CreateLogStreamOutput, error) {
 				return nil, nil
 			},
 
@@ -143,7 +141,7 @@ func TestCloudWatchLogProvider(t *testing.T) {
 	t.Run("Write Error", func(t *testing.T) {
 		writeCount := 0
 		client := CallbackCloudWatchLogs{
-			DescribeLogGroupsFn: func(ctx context.Context, input *cloudwatchlogs.DescribeLogGroupsInput) (*cloudwatchlogs.DescribeLogGroupsOutput, error) {
+			DescribeLogGroupsFn: func(input *cloudwatchlogs.DescribeLogGroupsInput) (*cloudwatchlogs.DescribeLogGroupsOutput, error) {
 				return &cloudwatchlogs.DescribeLogGroupsOutput{
 					LogGroups: []*cloudwatchlogs.LogGroup{
 						&cloudwatchlogs.LogGroup{LogGroupName: input.LogGroupNamePrefix},
@@ -151,11 +149,11 @@ func TestCloudWatchLogProvider(t *testing.T) {
 				}, nil
 			},
 
-			CreateLogGroupFn: func(ctx context.Context, input *cloudwatchlogs.CreateLogGroupInput) (*cloudwatchlogs.CreateLogGroupOutput, error) {
+			CreateLogGroupFn: func(input *cloudwatchlogs.CreateLogGroupInput) (*cloudwatchlogs.CreateLogGroupOutput, error) {
 				return nil, nil
 			},
 
-			CreateLogStreamFn: func(ctx context.Context, input *cloudwatchlogs.CreateLogStreamInput) (*cloudwatchlogs.CreateLogStreamOutput, error) {
+			CreateLogStreamFn: func(input *cloudwatchlogs.CreateLogStreamInput) (*cloudwatchlogs.CreateLogStreamOutput, error) {
 				return nil, nil
 			},
 
@@ -187,7 +185,7 @@ func TestCloudWatchLogProvider(t *testing.T) {
 func TestCloudWatchLogGroupExists(t *testing.T) {
 	t.Run("Success", func(t *testing.T) {
 		client := CallbackCloudWatchLogs{
-			DescribeLogGroupsFn: func(ctx context.Context, input *cloudwatchlogs.DescribeLogGroupsInput) (*cloudwatchlogs.DescribeLogGroupsOutput, error) {
+			DescribeLogGroupsFn: func(input *cloudwatchlogs.DescribeLogGroupsInput) (*cloudwatchlogs.DescribeLogGroupsOutput, error) {
 				return &cloudwatchlogs.DescribeLogGroupsOutput{
 					LogGroups: []*cloudwatchlogs.LogGroup{
 						&cloudwatchlogs.LogGroup{LogGroupName: input.LogGroupNamePrefix},
@@ -203,7 +201,7 @@ func TestCloudWatchLogGroupExists(t *testing.T) {
 
 	t.Run("Error", func(t *testing.T) {
 		client := CallbackCloudWatchLogs{
-			DescribeLogGroupsFn: func(ctx context.Context, input *cloudwatchlogs.DescribeLogGroupsInput) (*cloudwatchlogs.DescribeLogGroupsOutput, error) {
+			DescribeLogGroupsFn: func(input *cloudwatchlogs.DescribeLogGroupsInput) (*cloudwatchlogs.DescribeLogGroupsOutput, error) {
 				return nil, awserr.New("Invalid", "Invalid", nil)
 			},
 		}
@@ -217,7 +215,7 @@ func TestCloudWatchLogGroupExists(t *testing.T) {
 func TestCreateCloudWatchLogGroup(t *testing.T) {
 	t.Run("Success", func(t *testing.T) {
 		client := CallbackCloudWatchLogs{
-			CreateLogGroupFn: func(ctx context.Context, input *cloudwatchlogs.CreateLogGroupInput) (*cloudwatchlogs.CreateLogGroupOutput, error) {
+			CreateLogGroupFn: func(input *cloudwatchlogs.CreateLogGroupInput) (*cloudwatchlogs.CreateLogGroupOutput, error) {
 				return nil, nil
 			},
 		}
@@ -229,7 +227,7 @@ func TestCreateCloudWatchLogGroup(t *testing.T) {
 
 	t.Run("Error", func(t *testing.T) {
 		client := CallbackCloudWatchLogs{
-			CreateLogGroupFn: func(ctx context.Context, input *cloudwatchlogs.CreateLogGroupInput) (*cloudwatchlogs.CreateLogGroupOutput, error) {
+			CreateLogGroupFn: func(input *cloudwatchlogs.CreateLogGroupInput) (*cloudwatchlogs.CreateLogGroupOutput, error) {
 				return nil, awserr.New("Invalid", "Invalid", nil)
 			},
 		}
@@ -243,22 +241,22 @@ func TestCreateCloudWatchLogGroup(t *testing.T) {
 type CallbackCloudWatchLogs struct {
 	cloudwatchlogsiface.CloudWatchLogsAPI
 
-	DescribeLogGroupsFn func(ctx context.Context, input *cloudwatchlogs.DescribeLogGroupsInput) (*cloudwatchlogs.DescribeLogGroupsOutput, error)
-	CreateLogGroupFn    func(ctx context.Context, input *cloudwatchlogs.CreateLogGroupInput) (*cloudwatchlogs.CreateLogGroupOutput, error)
-	CreateLogStreamFn   func(ctx context.Context, input *cloudwatchlogs.CreateLogStreamInput) (*cloudwatchlogs.CreateLogStreamOutput, error)
+	DescribeLogGroupsFn func(input *cloudwatchlogs.DescribeLogGroupsInput) (*cloudwatchlogs.DescribeLogGroupsOutput, error)
+	CreateLogGroupFn    func(input *cloudwatchlogs.CreateLogGroupInput) (*cloudwatchlogs.CreateLogGroupOutput, error)
+	CreateLogStreamFn   func(input *cloudwatchlogs.CreateLogStreamInput) (*cloudwatchlogs.CreateLogStreamOutput, error)
 	PutLogEventsFn      func(input *cloudwatchlogs.PutLogEventsInput) (*cloudwatchlogs.PutLogEventsOutput, error)
 }
 
-func (cwl CallbackCloudWatchLogs) DescribeLogGroupsWithContext(ctx context.Context, input *cloudwatchlogs.DescribeLogGroupsInput, opts ...request.Option) (*cloudwatchlogs.DescribeLogGroupsOutput, error) {
-	return cwl.DescribeLogGroupsFn(ctx, input)
+func (cwl CallbackCloudWatchLogs) DescribeLogGroups(input *cloudwatchlogs.DescribeLogGroupsInput) (*cloudwatchlogs.DescribeLogGroupsOutput, error) {
+	return cwl.DescribeLogGroupsFn(input)
 }
 
-func (cwl CallbackCloudWatchLogs) CreateLogGroupWithContext(ctx context.Context, input *cloudwatchlogs.CreateLogGroupInput, opts ...request.Option) (*cloudwatchlogs.CreateLogGroupOutput, error) {
-	return cwl.CreateLogGroupFn(ctx, input)
+func (cwl CallbackCloudWatchLogs) CreateLogGroup(input *cloudwatchlogs.CreateLogGroupInput) (*cloudwatchlogs.CreateLogGroupOutput, error) {
+	return cwl.CreateLogGroupFn(input)
 }
 
-func (cwl CallbackCloudWatchLogs) CreateLogStreamWithContext(ctx context.Context, input *cloudwatchlogs.CreateLogStreamInput, opts ...request.Option) (*cloudwatchlogs.CreateLogStreamOutput, error) {
-	return cwl.CreateLogStreamFn(ctx, input)
+func (cwl CallbackCloudWatchLogs) CreateLogStream(input *cloudwatchlogs.CreateLogStreamInput) (*cloudwatchlogs.CreateLogStreamOutput, error) {
+	return cwl.CreateLogStreamFn(input)
 }
 
 func (cwl CallbackCloudWatchLogs) PutLogEvents(input *cloudwatchlogs.PutLogEventsInput) (*cloudwatchlogs.PutLogEventsOutput, error) {

--- a/cfn/logging/logging.go
+++ b/cfn/logging/logging.go
@@ -25,8 +25,6 @@ const (
 
 // SetProviderLogOutput ...
 func SetProviderLogOutput(w io.Writer) {
-	os.Stderr = nil
-	os.Stdout = nil
 
 	log.SetOutput(w)
 


### PR DESCRIPTION
*Issue #, if available:*
#136 
#153 
*Description of changes:*
* Creates the CloudWatch log group only once
* An error logging to CloudWatch is not fatal 
* Removes recursive logging

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
