### PR TITLE
subprocess.run arguments supported by python 3.6

### DIFF
--- a/python/rpdk/go/codegen.py
+++ b/python/rpdk/go/codegen.py
@@ -3,7 +3,7 @@
 import logging
 import zipfile
 from pathlib import Path
-from subprocess import CalledProcessError, run as subprocess_run
+from subprocess import PIPE, CalledProcessError, run as subprocess_run
 from tempfile import TemporaryFile
 
 from rpdk.core.data_loaders import resource_stream
@@ -174,7 +174,7 @@ class GoLanguagePlugin(LanguagePlugin):
         for path in format_paths:
             try:
                 subprocess_run(
-                    ["go", "fmt", path], cwd=root, check=True, capture_output=True
+                    ["go", "fmt", path], cwd=root, check=True, stdout=PIPE, stderr=PIPE
                 )
             except (FileNotFoundError, CalledProcessError) as e:
                 raise DownstreamError("go fmt failed") from e


### PR DESCRIPTION
Addresses #143 

Changes subprocess.run arguments to support Python 3.6. `capture_output=True` is converted to `stdout=PIPE, stderr=PIPE` [within the library](https://github.com/python/cpython/blob/3.8/Lib/subprocess.py#L482)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
