### PR TITLE
LIST returns empty array

### DIFF
--- a/cfn/handler/event.go
+++ b/cfn/handler/event.go
@@ -34,8 +34,11 @@ type ProgressEvent struct {
 	// and by CREATE/UPDATE/DELETE for final response validation/confirmation
 	ResourceModel interface{} `json:"resourceModel,omitempty"`
 
-	// ResourceModels is the output resource instances populated by a LIST for synchronous results
-	ResourceModels []interface{} `json:"resourceModels,omitempty"`
+	// ResourceModels is the output resource instances populated by a LIST for
+	// synchronous results. ResourceModels must be returned by LIST so it's
+	// always included in the response. When ResourceModels is not set, null is
+	// returned.
+	ResourceModels []interface{} `json:"resourceModels"`
 
 	// NextToken is the token used to request additional pages of resources for a LIST operation
 	NextToken string `json:"nextToken,omitempty"`

--- a/cfn/handler/event_test.go
+++ b/cfn/handler/event_test.go
@@ -1,0 +1,73 @@
+package handler
+
+import (
+	"testing"
+
+	"github.com/aws/aws-sdk-go/service/cloudformation"
+	"github.com/google/go-cmp/cmp"
+
+	"encoding/json"
+
+	"github.com/aws-cloudformation/cloudformation-cli-go-plugin/cfn/encoding"
+)
+
+func TestProgressEventMarshalJSON(t *testing.T) {
+	type Model struct {
+		Name    *encoding.String
+		Version *encoding.Float
+	}
+
+	for _, tt := range []struct {
+		name     string
+		event    ProgressEvent
+		expected string
+	}{
+		{
+			name: "not updatable",
+			event: ProgressEvent{
+				Message:         "foo",
+				OperationStatus: Failed,
+				ResourceModel: Model{
+					Name:    encoding.NewString("Douglas"),
+					Version: encoding.NewFloat(42.1),
+				},
+				HandlerErrorCode: cloudformation.HandlerErrorCodeNotUpdatable,
+			},
+			expected: `{"status":"FAILED","errorCode":"NotUpdatable","message":"foo","resourceModel":{"Name":"Douglas","Version":"42.1"},"resourceModels":null}`,
+		},
+		{
+			name: "list with 1 result",
+			event: ProgressEvent{
+				OperationStatus: Success,
+				ResourceModels: []interface{}{
+					Model{
+						Name:    encoding.NewString("Douglas"),
+						Version: encoding.NewFloat(42.1),
+					},
+				},
+			},
+			expected: `{"status":"SUCCESS","resourceModels":[{"Name":"Douglas","Version":"42.1"}]}`,
+		},
+		{
+			name: "list with empty array",
+			event: ProgressEvent{
+				OperationStatus: Success,
+				ResourceModels:  []interface{}{},
+			},
+			expected: `{"status":"SUCCESS","resourceModels":[]}`,
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+
+			actual, err := json.Marshal(tt.event)
+			if err != nil {
+				t.Errorf("Unexpected error marshaling event JSON: %s", err)
+			}
+
+			if diff := cmp.Diff(string(actual), tt.expected); diff != "" {
+				t.Errorf(diff)
+			}
+		})
+	}
+
+}

--- a/cfn/response.go
+++ b/cfn/response.go
@@ -31,8 +31,11 @@ type response struct {
 	//passed back to CloudFormation
 	BearerToken string `json:"bearerToken,omitempty"`
 
-	// ResourceModels is the output resource instances populated by a LIST for synchronous results
-	ResourceModels []interface{} `json:"resourceModels,omitempty"`
+	// ResourceModels is the output resource instances populated by a LIST for
+	// synchronous results. ResourceModels must be returned by LIST so it's
+	// always included in the response. When ResourceModels is not set, null is
+	// returned.
+	ResourceModels []interface{} `json:"resourceModels"`
 
 	// NextToken the token used to request additional pages of resources for a LIST operation
 	NextToken string `json:"nextToken,omitempty"`

--- a/cfn/response_test.go
+++ b/cfn/response_test.go
@@ -12,31 +12,66 @@ import (
 	"github.com/aws-cloudformation/cloudformation-cli-go-plugin/cfn/handler"
 )
 
-func TestMarshalJSON(t *testing.T) {
+func TestResponseMarshalJSON(t *testing.T) {
 	type Model struct {
 		Name    *encoding.String
 		Version *encoding.Float
 	}
 
-	r := response{
-		Message:         "foo",
-		OperationStatus: handler.Success,
-		ResourceModel: Model{
-			Name:    encoding.NewString("Douglas"),
-			Version: encoding.NewFloat(42.1),
+	for _, tt := range []struct {
+		name     string
+		response response
+		expected string
+	}{
+		{
+			name: "updated failed",
+			response: response{
+				Message:         "foo",
+				OperationStatus: handler.Failed,
+				ResourceModel: Model{
+					Name:    encoding.NewString("Douglas"),
+					Version: encoding.NewFloat(42.1),
+				},
+				ErrorCode:   cloudformation.HandlerErrorCodeNotUpdatable,
+				BearerToken: "xyzzy",
+			},
+			expected: `{"message":"foo","status":"FAILED","resourceModel":{"Name":"Douglas","Version":"42.1"},"errorCode":"NotUpdatable","bearerToken":"xyzzy","resourceModels":null}`,
 		},
-		ErrorCode:   cloudformation.HandlerErrorCodeNotUpdatable,
-		BearerToken: "xyzzy",
+		{
+			name: "list with 1 result",
+			response: response{
+				OperationStatus: handler.Success,
+				ResourceModels: []interface{}{
+					Model{
+						Name:    encoding.NewString("Douglas"),
+						Version: encoding.NewFloat(42.1),
+					},
+				},
+				BearerToken: "xyzzy",
+			},
+			expected: `{"status":"SUCCESS","bearerToken":"xyzzy","resourceModels":[{"Name":"Douglas","Version":"42.1"}]}`,
+		},
+		{
+			name: "list with empty array",
+			response: response{
+				OperationStatus: handler.Success,
+				ResourceModels:  []interface{}{},
+				BearerToken:     "xyzzy",
+			},
+			expected: `{"status":"SUCCESS","bearerToken":"xyzzy","resourceModels":[]}`,
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+
+			actual, err := json.Marshal(tt.response)
+			if err != nil {
+				t.Errorf("Unexpected error marshaling response JSON: %s", err)
+			}
+
+			if diff := cmp.Diff(string(actual), tt.expected); diff != "" {
+				t.Errorf(diff)
+			}
+		})
 	}
 
-	expected := `{"message":"foo","status":"SUCCESS","resourceModel":{"Name":"Douglas","Version":"42.1"},"errorCode":"NotUpdatable","bearerToken":"xyzzy"}`
-
-	actual, err := json.Marshal(r)
-	if err != nil {
-		t.Errorf("Unexpected error marshaling response JSON: %s", err)
-	}
-
-	if diff := cmp.Diff(string(actual), expected); diff != "" {
-		t.Errorf(diff)
-	}
 }


### PR DESCRIPTION
*Issue*

My resource provider fails `contract_delete_list` at [this line](https://github.com/aws-cloudformation/cloudformation-cli/blob/49dca0bb3b0931eeb79cf0151e8257037b154b1f/src/rpdk/core/contract/suite/handler_commons.py#L87) when no resources exist. 

```
    def get_resource_model_list(resource_client, current_resource_model):
        _status, response, _error_code = resource_client.call_and_assert(
            Action.LIST, OperationStatus.SUCCESS, current_resource_model
        )
        next_token = response.get("nextToken")
>       resource_models = response["resourceModels"]
E       KeyError: 'resourceModels'

...lib/python3.7/site-packages/rpdk/core/contract/suite/handler_commons.py:73: KeyError
```

My understanding of why is because of this [LIST contract requirement](https://docs.aws.amazon.com/cloudformation-cli/latest/userguide/resource-type-test-contract.html#resource-type-test-contract-list):

> A list request MUST return an empty array if there are no resources found.

and `resourceModels` is omitted from JSON marshalling when empty.

*Description of changes:*

Changes `resourceModels` to remove `omitempty`. Here's an example of the [before and after marshalling behavior](https://play.golang.org/p/YF67LF-mCzi).

When `resourceModels` is nil, it marshals as `"resourceModels": null`. This should work as expected with the contract tests because when `resourceModels` shouldn't be in the response [it's  expected to be `None`](https://github.com/aws-cloudformation/cloudformation-cli/blob/ee4203cc8f7b5ae8971194c5fa563d965fe330a8/src/rpdk/core/contract/resource_client.py#L331) 

```
Python 3.6.11 (default, Aug 31 2020, 14:05:31)
[GCC 4.2.1 Compatible Apple LLVM 10.0.0 (clang-1000.10.44.4)] on darwin
Type "help", "copyright", "credits" or "license" for more information.
>>> import json
>>> response = json.loads('{"resourceModels": null}')
>>> response["resourceModels"] is None
True
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
