### PR TITLE
Fix 'cfn generate' on Windows systems

### DIFF
--- a/python/rpdk/go/codegen.py
+++ b/python/rpdk/go/codegen.py
@@ -170,7 +170,7 @@ class GoLanguagePlugin(LanguagePlugin):
         LOG.debug("Writing project: %s", path)
         template = self.env.get_template("main.go.tple")
         importpath = Path(project.settings["import_path"])
-        contents = template.render(path=importpath / "cmd" / "resource")
+        contents = template.render(path=(importpath / "cmd" / "resource").as_posix())
         project.overwrite(path, contents)
         format_paths.append(path)
 


### PR DESCRIPTION
Pathlib by default converts the path format to Windows style on Windows machines. But the 'main.go' generated does not
accept windows style paths.

*Issue #, if available:* #123 

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
