### PR TITLE
Loosen requirements on cloudformation-cli

### DIFF
--- a/python/rpdk/go/__init__.py
+++ b/python/rpdk/go/__init__.py
@@ -1,5 +1,5 @@
 import logging
 
-__version__ = "2.0.3"
+__version__ = "2.0.4"
 
 logging.getLogger(__name__).addHandler(logging.NullHandler())

--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,7 @@ setup(
     # package_data -> use MANIFEST.in instead
     include_package_data=True,
     zip_safe=True,
-    install_requires=["cloudformation-cli>=0.1.2,<0.2", "semver>=2.9.0"],
+    install_requires=["cloudformation-cli>=0.1.14", "semver>=2.9.0"],
     python_requires=">=3.6",
     entry_points={
         "rpdk.v1.languages": ["go = rpdk.go.codegen:GoLanguagePlugin"],


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:* Remove upper bound requirement on the cloudformation-cli being <0.2 to accomodate for future releases.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
