### PR TITLE
Expose previous and current resource properties

### DIFF
--- a/cfn/handler/request.go
+++ b/cfn/handler/request.go
@@ -38,6 +38,14 @@ type Request struct {
 	resourcePropertiesBody         []byte
 }
 
+func (r *Request) GetPreviousResourcePropertiesBody() []byte {
+	return r.previousResourcePropertiesBody
+}
+
+func (r *Request) GetResourcePropertiesBody() []byte {
+	return r.resourcePropertiesBody
+}
+
 // RequestContext represents information about the current
 // invocation request of the handler.
 type RequestContext struct {

--- a/cfn/handler/request.go
+++ b/cfn/handler/request.go
@@ -38,11 +38,11 @@ type Request struct {
 	resourcePropertiesBody         []byte
 }
 
-func (r *Request) GetPreviousResourcePropertiesBody() []byte {
+func (r *Request) PreviousResourcePropertiesBody() []byte {
 	return r.previousResourcePropertiesBody
 }
 
-func (r *Request) GetResourcePropertiesBody() []byte {
+func (r *Request) ResourcePropertiesBody() []byte {
 	return r.resourcePropertiesBody
 }
 

--- a/cfn/handler/request_test.go
+++ b/cfn/handler/request_test.go
@@ -63,3 +63,59 @@ func TestUnmarshal(t *testing.T) {
 		t.Errorf(diff)
 	}
 }
+
+func TestNestedUnmarshal(t *testing.T) {
+	type Model struct {
+		Name    *string
+		Version *float64
+		Detail  map[string]interface{}
+	}
+
+	req := Request{
+		LogicalResourceID:              "foo",
+		previousResourcePropertiesBody: []byte(`{"Name":"bar","Version":"0.1","Detail":{"Nested":{"Build":"57","IsProduction":"false"}}}`),
+		resourcePropertiesBody:         []byte(`{"Name":"baz","Version":"2.3","Detail":{"Nested":{"Build":"69","IsProduction":"true"}}}`),
+	}
+
+	expectedPrevious := Model{
+		Name:    aws.String("bar"),
+		Version: aws.Float64(0.1),
+		Detail: map[string]interface{}{
+			"Nested": map[string]interface{}{
+				"Build":        aws.Int(57),
+				"IsProduction": aws.Bool(false),
+			},
+		},
+	}
+
+	expectedCurrent := Model{
+		Name:    aws.String("baz"),
+		Version: aws.Float64(2.3),
+		Detail: map[string]interface{}{
+			"Nested": map[string]interface{}{
+				"Build":        aws.Int(69),
+				"IsProduction": aws.Bool(true),
+			},
+		},
+	}
+
+	actual := Model{}
+
+	// Previous body
+	err := req.UnmarshalPrevious(&actual)
+	if err != nil {
+		t.Error(err)
+	}
+	if diff := cmp.Diff(actual, expectedPrevious); diff != "" {
+		t.Errorf(diff)
+	}
+
+	// Current body
+	err = req.Unmarshal(&actual)
+	if err != nil {
+		t.Error(err)
+	}
+	if diff := cmp.Diff(actual, expectedCurrent); diff != "" {
+		t.Errorf(diff)
+	}
+}


### PR DESCRIPTION
*Issue #, if available:*

https://github.com/aws-cloudformation/cloudformation-cli-go-plugin/issues/184


*Description of changes:*

Allows users to use their own Unmarshal strategy by exposing the making the raw resource bytes through a get method.

e.g.

```golang

       // Populate the previous model
	prevModel := &resource.Model{}
	if err := json.Unmarshal(req.GetPreviousResourcePropertiesBody(), prevModel); err != nil {
		log.Printf("Error unmarshaling prev model: %v", err)
		return handler.NewFailedEvent(err)
	}

	// Populate the current model
	currentModel := &resource.Model{}
	if err := json.Unmarshal(req.GetResourcePropertiesBody(), currentModel); err != nil {
		log.Printf("Error unmarshaling model: %v", err)
		return handler.NewFailedEvent(err)
	}

```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
