### PR TITLE
Fix unstringifying of large integers

### DIFF
--- a/cfn/encoding/unstringify.go
+++ b/cfn/encoding/unstringify.go
@@ -127,7 +127,7 @@ func convertInt(i interface{}, pointer bool) (reflect.Value, error) {
 		n = int(v)
 
 	case string:
-		n64, err := strconv.ParseInt(v, 0, 32)
+		n64, err := strconv.ParseInt(v, 0, 64)
 		if err != nil {
 			return zeroValue, err
 		}

--- a/cfn/encoding/unstringify_test.go
+++ b/cfn/encoding/unstringify_test.go
@@ -25,8 +25,8 @@ func TestUnstringifyStruct(t *testing.T) {
 		SP: aws.String("bar"),
 		B:  true,
 		BP: aws.Bool(true),
-		I:  42,
-		IP: aws.Int(42),
+		I:  2147483648, // math.MaxInt32 + 1
+		IP: aws.Int(2147483648),
 		F:  3.14,
 		FP: aws.Float64(22),
 	}
@@ -39,8 +39,8 @@ func TestUnstringifyStruct(t *testing.T) {
 			"SP": "bar",
 			"B":  "true",
 			"BP": "true",
-			"I":  "42",
-			"IP": "42",
+			"I":  "2147483648",
+			"IP": "2147483648",
 			"F":  "3.14",
 			"FP": "22",
 		}, &actual)
@@ -62,8 +62,8 @@ func TestUnstringifyStruct(t *testing.T) {
 			"SP": "bar",
 			"B":  true,
 			"BP": true,
-			"I":  42,
-			"IP": 42,
+			"I":  2147483648,
+			"IP": 2147483648,
 			"F":  3.14,
 			"FP": 22.0,
 		}, &actual)
@@ -85,8 +85,8 @@ func TestUnstringifyStruct(t *testing.T) {
 			"SP": "bar",
 			"B":  true,
 			"BP": true,
-			"I":  float64(42),
-			"IP": float64(42),
+			"I":  float64(2147483648),
+			"IP": float64(2147483648),
 			"F":  3.14,
 			"FP": int(22),
 		}, &actual)


### PR DESCRIPTION
Seeing errors in the handler when trying to unmarshal a model containing "large" integers.

```
Message: Unable to complete request: Marshaling: Unable to convert type
caused by: strconv.ParseInt: parsing "4294967294": value out of range
```

The use of `32` in `strconv.ParseInt` strikes me as a typo.



By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
