### PR TITLE
fix: gitignore template spelling for vendor folder

### DIFF
--- a/python/rpdk/go/data/go.gitignore
+++ b/python/rpdk/go/data/go.gitignore
@@ -8,8 +8,8 @@ rpdk.log*
 #compiled file
 bin/
 
-#vender
-vender/
+#vendor
+vendor/
 
 # contains credentials
 sam-tests/


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
