### PR TITLE
CW client creds refresh

### DIFF
--- a/cfn/cfn.go
+++ b/cfn/cfn.go
@@ -89,19 +89,19 @@ func makeEventFunc(h Handler) eventFunc {
 	return func(ctx context.Context, event *event) (response, error) {
 		ps := credentials.SessionFromCredentialsProvider(&event.RequestData.ProviderCredentials)
 		m := metrics.New(cloudwatch.New(ps), event.ResourceType)
-		once.Do(func() {
-			l, err := logging.NewCloudWatchLogsProvider(
-				cloudwatchlogs.New(ps),
-				event.RequestData.ProviderLogGroupName,
-			)
-			if err != nil {
-				log.Printf("Error: %v, Logging to Stdout", err)
-				m.PublishExceptionMetric(time.Now(), event.Action, err)
-				l = os.Stdout
-			}
-			// Set default logger to output to CWL in the provider account
-			logging.SetProviderLogOutput(l)
-		})
+
+		l, err := logging.NewCloudWatchLogsProvider(
+			cloudwatchlogs.New(ps),
+			event.RequestData.ProviderLogGroupName,
+		)
+		if err != nil {
+			log.Printf("Error: %v, Logging to Stdout", err)
+			m.PublishExceptionMetric(time.Now(), event.Action, err)
+			l = os.Stdout
+		}
+		// Set default logger to output to CWL in the provider account
+		logging.SetProviderLogOutput(l)
+
 		re := newReportErr(m)
 		if err := scrubFiles("/tmp"); err != nil {
 			log.Printf("Error: %v", err)


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
This change refreshes provider creds during runtime initialization
Test:
$ go test ./...
ok  	github.com/aws-cloudformation/cloudformation-cli-go-plugin/cfn	0.688s
ok  	github.com/aws-cloudformation/cloudformation-cli-go-plugin/cfn/callback	(cached)
?   	github.com/aws-cloudformation/cloudformation-cli-go-plugin/cfn/cfnerr	[no test files]
ok  	github.com/aws-cloudformation/cloudformation-cli-go-plugin/cfn/credentials	(cached)
ok  	github.com/aws-cloudformation/cloudformation-cli-go-plugin/cfn/encoding	(cached)
ok  	github.com/aws-cloudformation/cloudformation-cli-go-plugin/cfn/handler	(cached)
ok  	github.com/aws-cloudformation/cloudformation-cli-go-plugin/cfn/logging	(cached)
ok  	github.com/aws-cloudformation/cloudformation-cli-go-plugin/cfn/metrics	(cached)


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
