### PR TITLE
Force go to build with amd64 to cover Apple M1 chips

### DIFF
--- a/python/rpdk/go/templates/makebuild
+++ b/python/rpdk/go/templates/makebuild
@@ -4,4 +4,4 @@
 .PHONY: build
 build:
 	cfn generate
-	env GOOS=linux go build -ldflags="-s -w" -tags="$(TAGS)" -o bin/handler cmd/main.go
+	env GOARCH=amd64 GOOS=linux go build -ldflags="-s -w" -tags="$(TAGS)" -o bin/handler cmd/main.go


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
- `go build` configured for amd64 to cover Apple M1 chips

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
