### PR TITLE
Incorrect type conversion incase of empty map

### DIFF
--- a/cfn/encoding/stringify.go
+++ b/cfn/encoding/stringify.go
@@ -61,6 +61,9 @@ func Stringify(v interface{}) (interface{}, error) {
 				out[key.String()] = v
 			}
 		}
+		if len(out) == 0 {
+			return nil, nil
+		}
 		return out, nil
 	case reflect.Slice:
 		out := make([]interface{}, val.Len())


### PR DESCRIPTION
*Issue #, if available:*

When the Response is an empty map, an incorrect type conversion is seen. As the caller is checking on nil, type returning the nil fixes the error.

*Description of changes:*
Stack Trace:
```

{
  "errorMessage": "reflect.Set: value of type map[string]interface {} is not assignable to type string",
  "errorType": "string",
  "stackTrace": [
    {
      "path": "github.com/aws/aws-lambda-go@v1.13.3/lambda/function.go",
      "line": 35,
      "label": "(*Function).Invoke.func1"
    },
    {
      "path": "runtime/panic.go",
      "line": 884,
      "label": "gopanic"
    },
    {
      "path": "reflect/value.go",
      "line": 3145,
      "label": "Value.assignTo"
    },
    {
      "path": "reflect/value.go",
      "line": 2160,
      "label": "Value.Set"
    },
    {
      "path": "Users/mohittalniya/cloudformation-cli-go-plugin/cfn/encoding/stringify.go",
      "line": 103,
      "label": "Stringify"
    },
```


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
